### PR TITLE
moving to testr, refactoring

### DIFF
--- a/heat_setup.yml
+++ b/heat_setup.yml
@@ -1,5 +1,7 @@
 - name: "heat setup"
   hosts: undercloud   
+  roles:
+    - testconfig
   vars:
     ansible_python_interpreter: "/home/stack/ir_venv/bin/python"
   gather_facts: yes
@@ -27,87 +29,5 @@
       when:
         - ansible_local.custom.rhos.version == "10" or ansible_local.custom.rhos.version == "11" or ansible_local.custom.rhos.version == "12"
 
-    - include_vars:
-        file: images.yml
-        name: images
-    - name: download cirros and Fedora images
-      get_url:
-        url: "{{ item.url }}"
-        dest: "{{ item.dest }}"
-      with_items:
-        - {url: "{{ images.cirros_url }}", dest: '/tmp/cirros-0.3.4-x86_64-disk.img' }
-        - {url: "{{ images.fedora_url }}", dest: '/tmp/fedora-cloud-base-25-jenkins.qcow2' }
-    - name: upload cirros and Fedora images
-      os_image:
-        auth: "{{ os_creds }}"
-        name: "{{ item.name }}"
-        container_format: bare
-        is_public: yes
-        disk_format: qcow2
-        filename: "{{ item.filename }}"
-        state: present
-        validate_certs: no
-      with_items:
-        - {name: 'heat_cirros_image', filename: '/tmp/cirros-0.3.4-x86_64-disk.img' }
-        - {name: 'heat_fedora_image', filename: '/tmp/fedora-cloud-base-25-jenkins.qcow2' }
-    - name: Configure heat network on overcloud
-      os_network:
-        validate_certs: no
-        name: heat-net
-        auth: "{{ os_demo }}"
-    - name: Configure heat subnet on heat network
-      os_subnet:
-        network_name: heat-net
-        name: heat-subnet
-        cidr: 10.0.5.0/24
-        validate_certs: no
-        auth: "{{ os_demo }}"
-    - name: Configure heat router
-      os_router:
-        name: router1
-        auth: "{{ os_demo }}"
-        validate_certs: no
-        interfaces:
-          - heat-subnet
-    - name: Configure heat keypair
-      os_keypair:
-        name: heat_keypair
-        validate_certs: no
-        auth: "{{ os_demo }}"
-    - name: Configure heat m1.small flavor
-      os_nova_flavor:
-        ram: 2048
-        disk: 7
-        vcpus: 1
-        name: m1.small
-        validate_certs: no
-        auth: "{{ os_creds }}"
-    - name: create m1.tiny flavor
-      os_nova_flavor:
-        ram:  512
-        disk: 7
-        vcpus: 1
-        name: m1.tiny
-        validate_certs: no
-        auth: "{{ os_creds }}"
-    - name: set group regex into testr.conf
-      ini_file:
-        path: /home/stack/tempest-dir/.testr.conf
-        no_extra_spaces: yes
-        section: DEFAULT
-        option: group_regex
-        value: heat_integrationtests\.api\.test_heat_api(?:\.|_)([^_]+)
-        mode: 0642
-        backup: yes
-    - name: add swiftoperator role to demo user
-      shell: |
-        . /home/stack/overcloudrc
-        openstack role add --user demo --project demo swiftoperator
-    - name: modify nova network to public
-      shell: |
-        . /home/stack/overcloudrc
-        network="$(openstack network show -c name --format value public | tr -d '[:space:]')"
-        if [[ "$network" != "public" ]]; then openstack network set nova --name public; fi
-      ignore_errors: yes
 
 

--- a/images.yml
+++ b/images.yml
@@ -1,3 +1,0 @@
-cirros_url: http://ikook.tlv.redhat.com/gen_images/cloud/cirros-0.3.5-x86_64-disk.img
-fedora_url: http://ikook.tlv.redhat.com/uploads/InfraRed/Images/fedora-cloud-base-25-jenkins.qcow2
-

--- a/roles/testconfig/tasks/auth_demo.yml
+++ b/roles/testconfig/tasks/auth_demo.yml
@@ -1,0 +1,14 @@
+  - name: grab auth data from openstackrc for demo project
+    shell: |
+        source "{{ overcloudrc }}"
+        echo "
+        auth_url: $OS_AUTH_URL
+        username: demo
+        password: secrete
+        project_name: demo
+        "
+    register: creds
+  - set_fact:
+      os_demo: "{{ creds.stdout | from_yaml }}"
+        
+

--- a/roles/testconfig/tasks/auth_old.yml
+++ b/roles/testconfig/tasks/auth_old.yml
@@ -1,0 +1,31 @@
+  - name: grab auth data from openstackrc file and publish it as YAML
+    shell: |
+        source "{{ overcloudrc }}"
+        echo "
+        auth_url: $OS_AUTH_URL
+        username: $OS_USERNAME
+        password: $OS_PASSWORD
+        project_name: ${OS_PROJECT_NAME:-$OS_TENANT_NAME}
+        "
+        if [ -n "$OS_PROJECT_DOMAIN_NAME" ]; then
+            echo "project_domain_name: $OS_PROJECT_DOMAIN_NAME"
+        fi
+        if [ -n "$OS_USER_DOMAIN_NAME" ]; then
+            echo "user_domain_name: $OS_USER_DOMAIN_NAME"
+        fi
+    register: creds
+  - set_fact:
+      os_creds: "{{ creds.stdout | from_yaml }}"
+
+  - set_fact:
+      env:
+        OS_AUTH_TYPE: password
+        OS_AUTH_URL: "{{ os_creds.auth_url }}"
+        OS_CLOUDNAME: overcloud
+        OS_IDENTITY_API_VERSION: 2
+        OS_NO_CACHE: True
+        OS_PASSWORD: "{{ os_creds.password }}"
+        OS_PROJECT_DOMAIN_NAME: Default
+        OS_PROJECT_NAME: "{{ os_creds.project_name }}"
+        OS_USERNAME: "{{ os_creds.username }}"
+        OS_USER_DOMAIN_NAME: Default

--- a/roles/testconfig/tasks/collect_overcloud_vars.yml
+++ b/roles/testconfig/tasks/collect_overcloud_vars.yml
@@ -1,0 +1,11 @@
+- name: Register Auth
+  shell: "cat {{ overcloudrc }} | grep AUTH_URL | cut -d '=' -f 2"
+  register: osp_auth
+
+- name: Register User name
+  shell: "cat {{ overcloudrc }} | grep USERNAME | cut -d '=' -f 2"
+  register: osp_username
+
+- name: Register Password
+  shell: "cat {{ overcloudrc }} | grep OS_PASSWORD | cut -d '=' -f 2"
+  register: osp_password

--- a/roles/testconfig/tasks/main.yml
+++ b/roles/testconfig/tasks/main.yml
@@ -1,0 +1,148 @@
+---
+#- include_vars:
+#    file: images.yml
+#    name: images
+
+- name: source the overcloudrc file
+  shell: source "{{ overcloudrc }}"
+
+- import_tasks: auth_old.yml
+- import_tasks: auth_demo.yml
+- import_tasks: pip_setup.yml
+
+- name: set heat images into heat_integrationtests.conf file
+  ini_file:
+    path: "{{ integrationtests_path }}"
+    section: DEFAULT
+    create: yes
+    option: "{{ item.image_key }}"
+    value: "{{ item.image }}"
+  with_items:
+      - {image_key: 'minimal_image_ref', image: 'heat_cirros_image'}
+      - {image_key: 'image_ref', image: 'heat_fedora_image'}
+
+- name: Set heat flavors into heat_integrationtests.conf file
+  ini_file:
+    path: "{{ integrationtests_path }}"
+    section: DEFAULT
+    create: yes
+    option: "{{ item.flavor_key }}"
+    value: "{{ item.flavor }}"
+  with_items:
+      - {flavor_key: 'minimal_instance_type', flavor: 'm1.tiny'}
+      - {flavor_key: 'instance_type', flavor: 'm1.small'}
+
+- name: set testr.conf regex
+  ini_file:
+    path: /home/stack/heat/.testr.conf
+    section: DEFAULT
+    option: group_regex
+    value: heat_integrationtests\.api\.test_heat_api(?:\.|_)([^_]+)
+    mode: 0642
+    backup: yes
+
+- name: download cirros and Fedora images
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+  with_items:
+    - {url: "{{ cirros_url }}", dest: "/tmp/{{ cirros_url | basename }}"}
+    - {url: "{{ fedora_url }}", dest: "/tmp/{{ fedora_url | basename }}"}
+- name: upload cirros and Fedora images
+  os_image:
+    auth: "{{ os_creds }}"
+    name: "{{ item.name }}"
+    container_format: bare
+    is_public: yes
+    disk_format: qcow2
+    filename: "{{ item.filename }}"
+    state: present
+    validate_certs: no
+  with_items:
+    - {name: 'heat_cirros_image', filename: "tmp/{{ cirros_url |
+    basename }}"}
+    - {name: 'heat_fedora_image', filename: "tmp/{{ fedora_url |
+    basename }}"}
+- name: Configure heat network on overcloud
+  os_network:
+    validate_certs: no
+    name: heat-net
+    auth: "{{ os_demo }}"
+- name: Configure heat subnet on heat network
+  os_subnet:
+    network_name: heat-net
+    name: heat-subnet
+    cidr: 10.0.5.0/24
+    validate_certs: no
+    auth: "{{ os_demo }}"
+- name: Configure heat router
+  os_router:
+    name: router1
+    auth: "{{ os_demo }}"
+    validate_certs: no
+    interfaces:
+      - heat-subnet
+- name: Configure heat keypair
+  os_keypair:
+    name: heat_keypair
+    validate_certs: no
+    auth: "{{ os_demo }}"
+- name: Configure heat m1.small flavor
+  os_nova_flavor:
+    ram: 2048
+    disk: 7
+    vcpus: 1
+    name: m1.small
+    validate_certs: no
+    auth: "{{ os_creds }}"
+- name: create m1.tiny flavor
+  os_nova_flavor:
+    ram:  512
+    disk: 7
+    vcpus: 1
+    name: m1.tiny
+    validate_certs: no
+    auth: "{{ os_creds }}"
+- name: set group regex into testr.conf
+  ini_file:
+    path: /home/stack/tempest-dir/.testr.conf
+    no_extra_spaces: yes
+    section: DEFAULT
+    option: group_regex
+    value: heat_integrationtests\.api\.test_heat_api(?:\.|_)([^_]+)
+    mode: 0642
+    backup: yes
+- name: add swiftoperator role to demo user
+  shell: |
+    . "{{ overcloudrc }}"
+    openstack role add --user demo --project demo swiftoperator
+  ignore_errors: yes
+- name: Check for the public network
+  os_networks_facts:
+    name: public
+    auth: "{{ os_creds }}"
+    validate_certs: no
+
+- name: Create public network
+  os_network:
+    name: public
+    state: present
+    auth: "{{ os_creds }}"
+    validate_certs: no
+  when: openstack_networks == []
+
+- name: black list functional tests
+  ini_file:
+    path: "{{ integrationtests_path }}"
+    section: DEFAULT
+    option: skip_functional_test_list
+    value: "StackValidationTest, DeleteInProgressTest,RemoteStackTest
+    .test_stack_update, ZaqarEventSinkTest, ZaqarWaitConditionTest,
+    test_reload_on_sighup, TemplateResourceAdoptTest, StackTagTest,
+    OSWaitCondition, PurgeTest, test_signal_queues, AwsStackTest,
+    ZaqarSignalTransportTest, NotificationTest,ReloadOnSighupTest,
+    test_cancel_update_server_with_port, ResourceGroupAdoptTest"
+
+
+
+

--- a/roles/testconfig/tasks/main.yml
+++ b/roles/testconfig/tasks/main.yml
@@ -1,7 +1,4 @@
 ---
-#- include_vars:
-#    file: images.yml
-#    name: images
 
 - name: source the overcloudrc file
   shell: source "{{ overcloudrc }}"
@@ -9,6 +6,7 @@
 - import_tasks: auth_old.yml
 - import_tasks: auth_demo.yml
 - import_tasks: pip_setup.yml
+- import_tasks: collect_overcloud_vars.yml
 
 - name: set heat images into heat_integrationtests.conf file
   ini_file:
@@ -136,12 +134,37 @@
     path: "{{ integrationtests_path }}"
     section: DEFAULT
     option: skip_functional_test_list
-    value: "StackValidationTest, DeleteInProgressTest,RemoteStackTest
-    .test_stack_update, ZaqarEventSinkTest, ZaqarWaitConditionTest,
+    value: "ZaqarEventSinkTest, ZaqarWaitConditionTest,
     test_reload_on_sighup, TemplateResourceAdoptTest, StackTagTest,
     OSWaitCondition, PurgeTest, test_signal_queues, AwsStackTest,
     ZaqarSignalTransportTest, NotificationTest,ReloadOnSighupTest,
-    test_cancel_update_server_with_port, ResourceGroupAdoptTest"
+    test_cancel_update_server_with_port, ParallelDeploymentsTest,
+    ResourceGroupAdoptTest"
+- name: modify conf file
+  ini_file:
+    path: "{{ integrationtests_path }}"
+    section: DEFAULT
+    option: "{{ item.option }}"
+    value: "{{ item.value }}"
+  with_items:
+    - {option: "username", value: "demo"}
+    - {option: "password", value: "secrete"}
+    - {option: "auth_url", value: "{{ osp_auth.stdout }}"}
+    - {option: "tenant_name", value: "demo"}
+    - {option: "user_domain_name", value: "Default"}
+    - {option: "project_domain_name", value: "Default"}
+    - {option: "region", value: "regionOne"}
+    - {option: "auth.version", value: "2"}
+    - {option: "admin_username", value: "admin"}
+    - {option: "admin_password", value: "{{ osp_password.stdout }}"}
+    - {option: "keypair_name", value: "heat_keypair"}
+    - {option: "iamge_ref", value: "heat_fedora_image"}
+    - {option: "minimal_image", value: "heat_cirros_image"}
+    - {option: "minimal_instance_type", value: "m1.tiny"}
+    - {option: "instance_type", value: "m1.small"}
+    - {option: "image_ssh_user", value: "root"}
+
+
 
 
 

--- a/roles/testconfig/tasks/pip_setup.yml
+++ b/roles/testconfig/tasks/pip_setup.yml
@@ -1,0 +1,25 @@
+---
+- name: install pip executable
+  yum:
+    name: python-virtualenv.noarch
+    state: latest
+  become: true
+- name: install gcc executable
+  yum:
+    name: gcc
+    state: latest
+  become: true
+
+- name: create pip directory
+  pip:
+    name: pip
+    virtualenv: /home/stack/ir_venv
+    state: latest
+    virtualenv_site_packages: yes
+- name: install shade
+  pip:
+    name: shade
+    virtualenv: /home/stack/ir_venv
+    state: latest
+    virtualenv_site_packages: yes
+

--- a/roles/testconfig/vars/main.yml
+++ b/roles/testconfig/vars/main.yml
@@ -1,0 +1,6 @@
+---
+integrationtests_path: "/home/stack/heat/heat_integrationtests/heat_integrationtests.conf"
+
+cirros_url: "http://ikook.tlv.redhat.com/gen_images/cloud/cirros-0.3.5-x86_64-disk.img"
+fedora_url: "http://ikook.tlv.redhat.com/uploads/InfraRed/Images/fedora-cloud-base-25-jenkins.qcow2"
+overcloudrc: "/home/stack/overcloudrc"

--- a/run_old_versions.yml
+++ b/run_old_versions.yml
@@ -1,0 +1,31 @@
+---
+- name: install and run heat eol tests from upstream
+  hosts: undercloud
+  vars:
+    ansible_python_interpreter: "/home/stack/ir_venv/bin/python"
+  roles:
+    - testconfig
+  tasks:
+    - name: install git repo with tags
+      git:
+        repo: 'git://git.openstack.org/openstack/heat'
+        dest: /home/stack/heat
+        version: tags/mitaka-eol
+        clone: no
+        update: no
+
+
+    - name: run the requirements on virtualenv
+      pip:
+        virtualenv: /home/stack/ir_venv
+        requirements: /home/stack/heat/test-requirements.txt
+
+    - name: run tests with testr
+      shell: |
+        source /home/stack/overcloudrc
+        testr init
+        testr run heat_integrationtests.functional
+      args:
+        chdir: /home/stack/heat
+
+

--- a/run_old_versions.yml
+++ b/run_old_versions.yml
@@ -22,7 +22,7 @@
 
     - name: run tests with testr
       shell: |
-        source /home/stack/overcloudrc
+        source "{{ overcloudrc }}"
         testr init
         testr run heat_integrationtests.functional
       args:


### PR DESCRIPTION
By this change we will run old version tests with testr - without tempest which is not supported on RHOS8, RHOS9.
I have moved tasks under testconfig and let the heat_setup.yml smaller that should do the logics of determining which version to be tested